### PR TITLE
Add support for laika.opts file

### DIFF
--- a/bin/laika
+++ b/bin/laika
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+var fs = require('fs');
 var optimist = require('optimist');
-var argv = optimist
+
+var optionsParser = optimist
   .usage('\nLaika - testing framework for meteor.\nUsage: $0 [options] [path filter]')
 
   .describe('mport', 'specify mongodb port')
@@ -34,9 +36,11 @@ var argv = optimist
   .alias('deep-debug', 'D')
 
   .describe('help', 'show this help')
-  .alias('help', 'h')
+  .alias('help', 'h');
 
-  .argv;
+setDefaultsFromOptsFile(optionsParser, 'laika.opts');
+
+var argv = optionsParser.argv;
 
 laika = require('./_laika');
 
@@ -46,4 +50,21 @@ if(argv.help) {
   laika.version();
 } else {
   laika.run(argv);
+}
+
+function setDefaultsFromOptsFile(optionsParser, filePath) {
+  var optsFileArgs = parseOptsFile(filePath);
+  var fileOpts = optimist.parse(optsFileArgs);
+  return optionsParser.default(fileOpts);
+}
+
+function parseOptsFile(filePath) {
+  var opts = [];
+  if (fs.existsSync(filePath)) {
+    var fileValues = fs.readFileSync(filePath, 'utf8')
+      .trim()
+      .split(/[\s=]+/);
+    opts = opts.concat(fileValues);
+  }
+  return opts;
 }


### PR DESCRIPTION
Adds support for taking options from a `laika.opts` file, modeled on Mocha's `mocha.opts`, since a lot of Laika's options seem borrowed from there.

This should be useful for people using Coffeescript or BDD mode.
