### PR TITLE
Fix unflagged arguments parsing for `laika.opts`

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -55,7 +55,7 @@ module.exports = {
         }
       });
     }
-    
+
     function initialize() {
       logger.info('\n  injecting laika...');
       injector.inject();
@@ -75,7 +75,7 @@ module.exports = {
     function afterPhantomCreated(err, ph) {
       if(err) {
         logger.error('  please install phantomjs to countinue');
-        throw err; 
+        throw err;
       } else {
         phantom = ph;
         phantom._phantom.stdout.on('data', onPhantomLogs);
@@ -114,7 +114,7 @@ module.exports = {
       }
 
       var mocha = new Mocha(mochaOptions);
-      var testsPath = argv._[0] || './tests';
+      var testsPath = argv.args[0] || './tests';
       identifyTests(testsPath, mocha);
       var runner = mocha.run(function(failedCount) {
         var exitCode = (failedCount > 0)? 1: 0;
@@ -233,6 +233,6 @@ function generateIsSourceFileAllowed(compilers) {
   var allowOnlyProperSourceFiles = new RegExp('\\.'+fileExtensionsList+'$');
 
   return function(filename) {
-    return allowOnlyProperSourceFiles.test(filename); 
+    return allowOnlyProperSourceFiles.test(filename);
   }
 }

--- a/bin/_laika
+++ b/bin/_laika
@@ -168,7 +168,7 @@ module.exports = {
 
   version: function() {
     var packageJson = require('../package.json');
-    logger.log(packageJson.version);
+    return packageJson.version;
   },
 
   actions: require('../lib/actions')

--- a/bin/laika
+++ b/bin/laika
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+var fs = require('fs');
 var optimist = require('optimist');
-var argv = optimist
+
+var optionsParser = optimist
   .usage('\nLaika - testing framework for meteor.\nUsage: $0 [options] [path filter]')
 
   .describe('mport', 'specify mongodb port')
@@ -34,9 +36,11 @@ var argv = optimist
   .alias('deep-debug', 'D')
 
   .describe('help', 'show this help')
-  .alias('help', 'h')
+  .alias('help', 'h');
 
-  .argv;
+setDefaultsFromOptsFile(optionsParser, 'laika.opts');
+
+var argv = optionsParser.argv;
 
 laika = require('./_laika');
 
@@ -46,4 +50,21 @@ if(argv.help) {
   laika.version();
 } else {
   laika.run(argv);
+}
+
+function setDefaultsFromOptsFile(optionsParser, filePath) {
+  var optsFileArgs = parseOptsFile(filePath);
+  var fileOpts = optimist.parse(optsFileArgs);
+  return optionsParser.default(fileOpts);
+}
+
+function parseOptsFile(filePath) {
+  var opts = [];
+  if (fs.existsSync(filePath)) {
+    var fileValues = fs.readFileSync(filePath, 'utf8')
+      .trim()
+      .split(/[\s=]+/);
+    opts = opts.concat(fileValues);
+  }
+  return opts;
 }

--- a/bin/laika
+++ b/bin/laika
@@ -40,7 +40,7 @@ var optionsParser = optimist
 
 setDefaultsFromOptsFile(optionsParser, 'laika.opts');
 
-var argv = optionsParser.argv;
+var argv = optionsParser.parse(process.argv.slice(2));
 
 laika = require('./_laika');
 

--- a/bin/laika
+++ b/bin/laika
@@ -1,70 +1,36 @@
 #!/usr/bin/env node
 var fs = require('fs');
-var optimist = require('optimist');
-
-var optionsParser = optimist
-  .usage('\nLaika - testing framework for meteor.\nUsage: $0 [options] [path filter]')
-
-  .describe('mport', 'specify mongodb port')
-  .default('mport', 27017)
-  .alias('mport', 'm')
-
-  .describe('ui', 'specify test user interfaces (tdd|bdd)')
-  .default('ui', 'tdd')
-  .alias('ui', 'u')
-
-  .describe('reporter', 'specify reporter to use (support all mocha reporters)')
-  .default('reporter', 'spec')
-  .alias('reporter', 'R')
-
-  .describe('timeout', 'test-case timeout in milliseconds')
-  .default('timeout', 2000)
-  .alias('timeout', 't')
-
-  .describe('compilers', '<ext>:<module>,...  use the given module(s) to compile files')
-  .alias('compilers','c')
-
-  .describe('version', 'print version')
-  .alias('version', 'v')
-
-  .describe('debug', 'print logs from client/server')
-  .default('debug', false)
-  .alias('debug', 'd')
-
-  .describe('deep-debug', 'print more debug logs')
-  .default('deep-debug', false)
-  .alias('deep-debug', 'D')
-
-  .describe('help', 'show this help')
-  .alias('help', 'h');
-
-setDefaultsFromOptsFile(optionsParser, 'laika.opts');
-
-var argv = optionsParser.parse(process.argv.slice(2));
+var commander = require('commander');
 
 laika = require('./_laika');
 
-if(argv.help) {
-  optimist.showHelp();
-} else if(argv.v) {
-  laika.version();
-} else {
-  laika.run(argv);
-}
+var optionsParser = commander
+  .usage('\nLaika - testing framework for meteor.\nUsage: $0 [options] [path filter]')
+  .version(laika.version())
+  .option('-m, --mport <port>', 'specify mongodb port [default: 27017]', 27017)
+  .option('-u, --ui <tdd|bdd>', 'specify test user interfaces (tdd|bdd) [default: tdd]', 'tdd')
+  .option('-R, --reporter <mocha_reporter>', 'specify reporter to use (support all mocha reporters) [default: spec]', 'spec')
+  .option('-t, --timeout <ms>', 'test-case timeout in milliseconds [default: 2000]', 2000)
+  .option('-c, --compilers <ext:module>', 'use the given module(s) to compile files')
+  .option('-d, --debug', 'print logs from client/server', false)
+  .option('-D, --deep-debug', 'print more debug logs', false);
 
-function setDefaultsFromOptsFile(optionsParser, filePath) {
-  var optsFileArgs = parseOptsFile(filePath);
-  var fileOpts = optimist.parse(optsFileArgs);
-  return optionsParser.default(fileOpts);
-}
+process.argv = parseOptsFile('laika.opts', process.argv);
+var argv = optionsParser.parse(process.argv);
 
-function parseOptsFile(filePath) {
-  var opts = [];
+laika.run(argv);
+
+function parseOptsFile(filePath, argv) {
+  newArgv = argv;
   if (fs.existsSync(filePath)) {
-    var fileValues = fs.readFileSync(filePath, 'utf8')
+    var opts = fs.readFileSync(filePath, 'utf8')
       .trim()
-      .split(/[\s=]+/);
-    opts = opts.concat(fileValues);
+      .split(/\s+/)
+      .filter(function(el){ return el !== ''; });
+
+    newArgv = argv
+      .slice(0, 2)
+      .concat(opts.concat(process.argv.slice(2)));
   }
-  return opts;
+  return newArgv;
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "colors": "0.6.x",
     "qbox": "0.1.x",
     "mongodb": "1.3.x",
-    "optimist": "0.5.x",
-    "fibers": "1.0.x"
+    "fibers": "1.0.x",
+    "commander": "~2.0.0"
   },
   "bin": {
     "laika": "./bin/laika"


### PR DESCRIPTION
This should fix the bug shipped with #41. The call to `optimist#parse` was overriding its `argv`.

The `slice` fix is a bit hacky but that's what `optimist` does before passing `process.argv` to `#parse`. That part is private, so I'm left with no DRY solution, unless we prefer to refactor `optimist` and send a PR there.

I looked into adding a regression test but it would take a bit of refactoring to make this file more test-friendly. Let me know if you prefer me to do that before we consider merging.
