### PR TITLE
Option for meteor settings file

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -86,7 +86,12 @@ module.exports = {
 
     deps.ready(function() {
       logger.info('  loading initial app pool...');
-      appPool = new AppPool({size: 2, appDir: './', mongoPort: argv.mport});
+      appPool = new AppPool({
+          size: 2,
+          appDir: './',
+          mongoPort: argv.mport,
+          settingsFile: argv.settings
+      });
       appPool.on('ready', onAppPoolReady);
 
       if(argv.ui == 'tdd') {

--- a/bin/laika
+++ b/bin/laika
@@ -10,6 +10,7 @@ var optionsParser = commander
   .option('-m, --mport <port>', 'specify mongodb port [default: 27017]', 27017)
   .option('-u, --ui <tdd|bdd>', 'specify test user interfaces (tdd|bdd) [default: tdd]', 'tdd')
   .option('-R, --reporter <reporter>', 'specify reporter to use (support all mocha reporters) [default: spec]', 'spec')
+  .option('-s, --settings <settings-file>', 'specify a settings file for your meteor app')
   .option('-t, --timeout <ms>', 'test-case timeout in milliseconds [default: 2000]', 2000)
   .option('-c, --compilers <ext:module>', 'use the given module(s) to compile files')
   .option('-d, --debug', 'print logs from client/server', false)

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,7 +20,7 @@ function App(config) {
   this.meteorApp;
   var laikaInjectPort;
 
-  this.start = function start(dbname, port) {
+  this.start = function start(dbname, port, settingsFile) {
     this.dbname = dbname;
     this.port = port;
 
@@ -31,6 +31,10 @@ function App(config) {
     process.env.MONGO_URL = App.getMongoUrl(config.mongoPort, this.dbname);
     process.env.PORT = port;
     process.env.ROOT_URL = 'http://localhost:' + port;
+
+    if (settingsFile) {
+      process.env.METEOR_SETTINGS = JSON.stringify(require(settingsFile));
+    }
 
     var meteorBin = (config.meteorite)? 'meteorite': 'meteor';
     logger.laika('using nodejs bin' + '(from ' +  meteorBin + ')' + ': ' + config.nodeBinary);
@@ -85,7 +89,7 @@ function App(config) {
       this.meteorApp.stdout.removeAllListeners('data');
       this.meteorApp.removeAllListeners('error');
       this.meteorApp.kill('SIGKILL');
-      
+
       var mongoUrl = App.getMongoUrl(config.mongoPort, this.dbname);
       helpers.dropMongoDatabase(mongoUrl, callback);
     } else {
@@ -137,7 +141,7 @@ App.touch = function touch(callback, options) {
   function onErrorData(data) {
     logger.touch(data.toString());
   }
-  
+
   function cleanup() {
     app.removeListener('error', onError);
     app.stdout.removeListener('data', onData);

--- a/lib/app_pool.js
+++ b/lib/app_pool.js
@@ -28,17 +28,17 @@ function AppPool(options) {
       createApp(createInitialPool);
     } else {
       self.emit('ready');
-    } 
+    }
   }
   setTimeout(createInitialPool, 0);
-  
+
   function createApp(callback) {
     var app = new App(appConfig);
     var dbname = 'laika-' + helpers.randomId(10);
     var port = helpers.getRandomPort();
-    
+
     if(callback) app.ready(callback);
-    app.start(dbname, port);  
+    app.start(dbname, port, options.settingsFile);
     pool.push(app);
   }
 


### PR DESCRIPTION
Some applications use a settings file, given via the `--settings` argument to the
`meteor`/`mrt` command or as a JSON string assigned to the `METEOR_SETTINGS`
environmental variable on self-hosted environments.

By providing an argument to --settings it is now possible to provide the
location of the meteor settings file and this is read, stringified and assigned
to the `METEOR_SETTINGS` environmental variable for each app.

Example usage

```
laika --settings settings.json
```

Note: if you're wondering about the white-space changes and new line, my vim does that automatically, I hope you don't mind.
