### PR TITLE
Changes for Windows support

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -63,7 +63,7 @@ module.exports = {
       App.touch(deps.tick.bind(deps), {mongoPort: argv.mport});
 
       logger.info('  loading phantomjs...');
-      Phantom.create(afterPhantomCreated, {parameters: {
+      Phantom.create(afterPhantomCreated, {phantomPath:require('phantomjs').path, parameters: {
         'load-images': false
       }});
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -117,6 +117,10 @@ App.touch = function touch(callback, options) {
 
   process.env.MONGO_URL = dbUrl;
   var meteorBinary = detectMeteorBinary();
+  if (process.platform ==="win32") {
+    meteorBinary = meteorBinary  + ".bat";
+    process.env.HOME = process.env.LOCALAPPDATA;
+  }
   var app = spawn(meteorBinary, ['--port', port], {
     cwd: options.appDir,
     env: process.env


### PR DESCRIPTION
- Meteor on Windows (win.meteor.com) uses a bat file to start meteor.
- HOME ===  LOCALAPPDATA.
