### PR TITLE
waitForDOM function to wait until e.g. IronRouter is done rendering

### DIFF
--- a/lib/injector/templates/client.js
+++ b/lib/injector/templates/client.js
@@ -8,3 +8,50 @@ window.emit = function emit() {
     window.callPhantom(payload);
   }
 };
+
+window.waitForDOM = function(selector, callback) {
+    var checker, observer, checkDOM;
+    if(typeof selector === 'function') {
+        checkDOM = selector;
+    } else if(window.$ === undefined) {
+        // You can use this without jQuery, but then you're limited to IDs or
+        // passing a function
+        if(selector[0] === '#') {
+            checkDOM = function() {
+                return document.getElementById(selector.substr(1)) !== null;
+            }
+        } else {
+            throw new TypeError("When jQuery isn't installed, you're limited to selectors in the #id form. Or pass your own function!")
+        }
+    } else {
+        checkDOM = function() {
+            return checkDOM() !== 0;
+        }
+    }
+
+    if(checkDOM()) {
+        callback();
+    } else if(window.MutationObserver !== undefined) {
+        observer = new MutationObserver(function() {
+            if(checkDOM()) {
+                callback();
+                observer.disconnect();
+            }
+        });
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            characterData: false
+        });
+    } else {
+        checker = function() {
+            if(checkDOM()) {
+                return callback();
+            } else {
+                return Meteor.setTimeout(checker, 50);
+            }
+        };
+        checker();
+    }
+};


### PR DESCRIPTION
Problem: I want to do end-to-end testing by “clicking” widgets in my view and checking that the expected results happen. But since we're using Iron Router, the elements don't actually exist yet at the time client.eval() gets to it, or even at Meteor.Startup() time.

Solution: a waitForDOM(selector, callback) function is injected in the client. When anything exists that matches the selector, the callback gets called. If My app is so broken that the view never renders, Laika will timeout and (correctly) give me a fail.

The selector can be anything jQuery can handle if you're using jQuery; if you're not, a function or a '#id'-style selector.

Example of use (Coffee) (not a particularly good test though):

``` coffeescript
describe 'Landing page', ->
    it 'Should load for unauthenticated users', (done, server, client) ->
        client.eval ->
            waitForDOM 'h1', ->
                emit 'login-link-text', $('#login-sign-in-link').text()
                h1 = $('h1')
                emit 'h1-len', h1.length
                emit 'full-text', $('body').text()
                emit 'return'
        .once 'login-link-text', (text) ->
            assert.equal text, 'Sign in ▾'
        .once 'h1-len', (len) ->
            assert.equal len, 1
        .once 'full-text', (text) ->
            assert.equal text.match(/my games/i), null
        .once 'return', ->
            done()
```
