### PR TITLE
added waitForRoute function to client template

### DIFF
--- a/lib/injector/templates/client.js
+++ b/lib/injector/templates/client.js
@@ -55,3 +55,21 @@ window.waitForDOM = function(selector, callback) {
         checker();
     }
 };
+
+window.waitForRoute = function(path, callback) {
+  if (!Router || !Router.current) {
+    throw new Error('waitForRoute currently only works with iron router');
+  }
+  if (Router.current().path == path) {
+    callback();
+  }
+  else {
+    Deps.autorun(function() {
+      if (Router.current().path == path) {
+        this.stop();
+        callback();
+      }
+    });
+    Router.go(path);
+  }
+}


### PR DESCRIPTION
Use like this:

```
client.eval(function() {
    waitForRoute('/path/to/route', function() {
        doSomethingAsSoonAsThePageIsReady();
    });
});
```

I tested it like this and it seems to work. The page appears to be fully rendered when the callback executes.
I would have updated the gh-pages as well but I don't exactly know how and where to put this in the docs. Any suggestions, @arunoda, @lalomartins?
