### PR TITLE
fix embarrassing search/replace bug in waitForDOM; would crash with jQuery

### DIFF
--- a/lib/injector/templates/client.js
+++ b/lib/injector/templates/client.js
@@ -25,7 +25,7 @@ window.waitForDOM = function(selector, callback) {
         }
     } else {
         checkDOM = function() {
-            return checkDOM() !== 0;
+            return $(selector).length !== 0;
         }
     }
 


### PR DESCRIPTION
embarrassingly enough, when I search-replace'd $(selector).length to checkDOM(), I somehow didn't exclude the one instance where checkDOM() is actually implemented. That causes tests to crash with maximum recursion depth exceeded.
