### PR TITLE
ignore node_modules

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -163,6 +163,9 @@ module.exports = {
       var files = fs.readdirSync(dir);
 
       files.forEach(function(file) {
+        if (file === 'node_modules') {
+          return;
+        }
         var filename = path.resolve(dir, file);
         var stat = fs.statSync(filename);
         if(stat.isDirectory()) {


### PR DESCRIPTION
As per [The New Laika hackpad](https://hackpad.com/The-New-Laika-ISvx59CC2ba#:h=Support-for-Custom-NPM-Modules), ignore node_modules when scanning tests. (Just got hit by this in my prototype, since Laika decided to run all the webdriver tests :grinning:)
