### PR TITLE
Expose Fibers and Future to plug-ins

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -38,6 +38,7 @@ module.exports = {
     var isSourceFileAllowed = generateIsSourceFileAllowed(compilers);
 
     helpers.makeAssertFiberFriendly();
+    helpers.exportFibers();
 
     //laika drops dbs after the test without any problem
     //if if you close laika with "CTRL + C" or laika got some internal error

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -77,7 +77,7 @@ exports.makeAssertFiberFriendly = function makeAssertFiberFriendly() {
       var args = arguments;
       if(Fibers.current) {
         var future = new Future();
-        
+
         process.nextTick(function() {
           method.apply(assert, args);
           future.return();
@@ -89,6 +89,12 @@ exports.makeAssertFiberFriendly = function makeAssertFiberFriendly() {
       }
     };
   }
+};
+
+exports.exportFibers = function exportFibers() {
+  // work around https://github.com/laverdet/node-fibers/issues/102
+  global.Fibers = Fibers;
+  global.Future = Future;
 };
 
 exports.checkForMongoDB = function checkForMongoDB(mongoUrl, callback) {


### PR DESCRIPTION
Plug-ins can't require their own Fibers because of https://github.com/laverdet/node-fibers/issues/102 (basically two different copies of Fibers will have different opinions about what's the current running fiber). As a temporary work-around, expose Fibers and Future as globals.
