### PR TITLE
first steps to new architecture

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -193,7 +193,6 @@ module.exports = {
             for(packageName in notInstalled) {
               loadPluginPackage(testsPath, packageName);
             }
-            process.exit(0);
             process.chdir(cwd);
             deps.tick();
           });

--- a/bin/_laika
+++ b/bin/_laika
@@ -14,9 +14,11 @@ var Mocha = require('mocha');
 var fs = require('fs');
 var path = require('path');
 var exec = require('child_process').exec;
+var npm = require('npm');
 
 var injector = new Injector();
-var deps = qbox.create(2);
+var deps;
+var plugins = [];
 var phantom;
 var appPool;
 var ended = false;
@@ -33,6 +35,13 @@ module.exports = {
       logger.setVerbose(true);
       logger.setDeepVerbose(true);
     }
+
+    var args = argv.args;
+    if (!args.length) {
+      args.push('./tests')
+    }
+    // potential plug-in directories + phantom + appPool
+    deps = qbox.create(args.length + 2);
 
     var compilers = parseCompilers(argv.compilers);
     var isSourceFileAllowed = generateIsSourceFileAllowed(compilers);
@@ -63,10 +72,13 @@ module.exports = {
       injector.inject();
       App.touch(deps.tick.bind(deps), {mongoPort: argv.mport});
 
+      // treat it as much as possible as a "built-in plug-in" for now
       logger.info('  loading phantomjs...');
       Phantom.create(afterPhantomCreated, {parameters: {
         'load-images': false
       }});
+
+      args.forEach(loadPlugins);
 
       //make sure this get ended everytime
       process.once('exit', function() {
@@ -82,6 +94,7 @@ module.exports = {
         phantom = ph;
         phantom._phantom.stdout.on('data', onPhantomLogs);
         phantom._phantom.stderr.on('data', onPhantomLogs);
+        // plugins.push(...);
         deps.tick();
       }
     }
@@ -97,16 +110,16 @@ module.exports = {
       appPool.on('ready', onAppPoolReady);
 
       if(argv.ui == 'tdd') {
-        test = testLogic(appPool, phantom);
+        test = testLogic(appPool, plugins, phantom);
         ltest = ltestWithWarning(test);
       } else if(argv.ui == 'bdd') {
-        it = testLogic(appPool, phantom);
+        it = testLogic(appPool, plugins, phantom);
       }
     });
 
     function onAppPoolReady() {
       // require('mocha/bin/_mocha');
-      var mochaOptions= {
+      var mochaOptions = {
           reporter: argv.reporter,
           ui: argv.ui,
           timeout: argv.timeout,
@@ -126,10 +139,6 @@ module.exports = {
       }
 
       var mocha = new Mocha(mochaOptions);
-      var args = argv.args;
-      if (!args.length) {
-        args.push('./tests')
-      }
       args.forEach(function (arg) {
         identifyTests(arg, mocha);
       })
@@ -139,19 +148,94 @@ module.exports = {
       });
     }
 
-    function identifyTests(path, mocha) {
-      var stat = fs.statSync(path);
-      if(stat.isDirectory()) {
-        scanFiles(path, mocha, {});
-      } else {
-        if (fs.existsSync(path)) {
-          mocha.addFile(path)
+    function loadPlugins(testsPath) {
+      // could test if path is a dir like for identifyTests, but if it isn't the
+      // package.json is just not going to be found...
+      // TODO: if a test *file* is specified, should we load plugins from the
+      // parent dir? --LaloMartins
+      testsPath = path.resolve(testsPath);
+      try {
+        var json = require(testsPath + '/package.json');
+      } catch(error) {
+        if(error.code === 'MODULE_NOT_FOUND') {
+          deps.tick();
+          return;
         } else {
-          if (fs.existsSync(path + '.js')) {
-            path += '.js'
-            mocha.addFile(path)
+          throw error;
+        }
+      }
+
+      var notInstalled = [], spec = [];
+      for(packageName in json.dependencies) {
+        if(!loadPluginPackage(testsPath, packageName)) {
+          notInstalled.push(packageName);
+          spec.push(packageName + '@' + json.dependencies[packageName]);
+        }
+      }
+      if(notInstalled.length === 0) {
+        deps.tick();
+      } else {
+        logger.info('  installing plug-ins: ' + notInstalled.join(', '));
+        var cwd = process.cwd();
+        process.chdir(testsPath);
+        npm.load({verbose: argv.verbose}, function(error, Npm) {
+          if(error) {
+            // this doesn't seem to ever happen though
+            logger.error('  failed to inintialize Npm');
+            logger.error(error);
+            process.exit(1);
+          }
+          Npm.commands.install(spec, function(error, installed) {
+            if(error != null) {
+              logger.error('  ' + error.message);
+              process.exit(1);
+            }
+            for(packageName in notInstalled) {
+              loadPluginPackage(testsPath, packageName);
+            }
+            process.exit(0);
+            process.chdir(cwd);
+            deps.tick();
+          });
+        });
+      }
+    }
+
+    function loadPluginPackage(where, packageName) {
+      logger.info('  loading ' + packageName + ' from ' + where + '...');
+      try {
+        var package = require(where + '/node_modules/' + packageName);
+      } catch(error) {
+        if(error.code === 'MODULE_NOT_FOUND') {
+          return false;
+        } else {
+          throw error;
+        }
+      }
+      var helper = package.laikaHelper;
+      if(helper !== undefined) {
+        plugins.push({
+          name: packageName,
+          from: where,
+          helper: helper
+        });
+      }
+      return true;
+    }
+
+    function identifyTests(testsPath, mocha) {
+      var stat = fs.statSync(testsPath);
+      if(stat.isDirectory()) {
+        scanFiles(testsPath, mocha, {});
+      } else {
+        if (fs.existsSync(testsPath)) {
+          mocha.addFile(testsPath)
+        } else {
+          if (fs.existsSync(testsPath + '.js')) {
+            testsPath += '.js'
+            mocha.addFile(testsPath)
           } else {
-            glob.sync(path).forEach(function (file) {
+            glob.sync(testsPath).forEach(function (file) {
               mocha.addFile(file)
             })
           }
@@ -185,13 +269,17 @@ module.exports = {
         logger.info('  cleaning up injected code\n');
         injector.clean();
 
-        phantom._phantom.stdout.removeListener('data', onPhantomLogs);
-        phantom._phantom.stderr.removeListener('data', onPhantomLogs);
-        phantom.exit();
+        if(phantom !== undefined) {
+          phantom._phantom.stdout.removeListener('data', onPhantomLogs);
+          phantom._phantom.stderr.removeListener('data', onPhantomLogs);
+          phantom.exit();
+        }
 
-        appPool.close(function() {
-          process.exit(exitCode);
-        });
+        if(appPool !== undefined) {
+          appPool.close(function() {
+            process.exit(exitCode);
+          });
+        }
         ended = true;
       }
     }

--- a/lib/test_logic.js
+++ b/lib/test_logic.js
@@ -3,7 +3,7 @@ var ClientConnector = require('./connectors/client.js');
 var Fiber = require('fibers');
 var logger = require('./logger');
 
-module.exports = function(appPool, phantom) {
+module.exports = function(appPool, plugins, phantom) {
   return function testLogic(message, callback) {
 
     if(this._test) {
@@ -11,9 +11,9 @@ module.exports = function(appPool, phantom) {
     } else if(this._it) {
       this._it(message, mockTest);
     }
-    
-    function mockTest(done) { 
-      logger.laika('start running test');   
+
+    function mockTest(done) {
+      logger.laika('start running test');
       var completed = false;
       var args = [];
       var app;
@@ -31,20 +31,32 @@ module.exports = function(appPool, phantom) {
         var hostnames = ["localhost", "127.0.0.1", "0.0.0.0"];
 
         app.ready(function(injectPort) {
-          args = [cleanAndDone, new ServerConnector(injectPort)];
-          var noClients = callback.length - 2;
-          var hostnameIssueWarned = false;
-          for(var lc = 0; lc<noClients; lc++) {
-            if(lc >= hostnames.length && !hostnameIssueWarned) {
-              logger.error('  WARN: It is recommended to use 3 clients only. see more - http://goo.gl/MMX3A');
-              hostnameIssueWarned = true;
-            }
-            var hostname = hostnames[lc] || "localhost";
-            var appUrl = "http://" + hostname + ":" + appPort;
-            args.push(new ClientConnector(phantom, appUrl));
-          }
-
           Fiber(function() {
+            var server = new ServerConnector(injectPort);
+            plugins.forEach(function(plugin) {
+              if(typeof plugin.helper.instrumentServer === 'function') {
+                plugin.helper.instrumentServer(server);
+              }
+            });
+            args = [cleanAndDone, server];
+            var noClients = callback.length - 2;
+            var hostnameIssueWarned = false;
+            for(var lc = 0; lc<noClients; lc++) {
+              if(lc >= hostnames.length && !hostnameIssueWarned) {
+                logger.error('  WARN: It is recommended to use 3 clients only. see more - http://goo.gl/MMX3A');
+                hostnameIssueWarned = true;
+              }
+              var hostname = hostnames[lc] || "localhost";
+              var appUrl = "http://" + hostname + ":" + appPort;
+              var client = new ClientConnector(phantom, appUrl);
+              plugins.forEach(function(plugin) {
+                if(typeof plugin.helper.instrumentClient === 'function') {
+                  plugin.helper.instrumentClient(client);
+                }
+              });
+              args.push(client);
+            }
+
             logger.laika('running test');
             callback.apply(null, args);
           }).run();
@@ -56,7 +68,7 @@ module.exports = function(appPool, phantom) {
           args.slice(1).forEach(function(connector) {
             connector.close();
           });
-          completeTest();      
+          completeTest();
         }
       }
 


### PR DESCRIPTION
- load plugins in package.json for each test directory
- install any plugins not found
- call `instrumentClient()` and `instrumentServer()` if defined

I was able to run my webdriver-based tests using this version of Laika (and removing the lines in the test code that manually import laika-webdriver and wrap the client, of course). I pushed the modified [laika-webdriver](https://github.com/lalomartins/laika-webdriver) as well, you want to see it.
