### PR TITLE
change plug-in loading according to our discussion

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -17,11 +17,12 @@ var exec = require('child_process').exec;
 var npm = require('npm');
 
 var injector = new Injector();
-var deps;
+var deps = qbox.create(3); // app, phantom, plug-ins
 var plugins = [];
 var phantom;
 var appPool;
 var ended = false;
+const DEFAULT_TEST_DIR = './tests';
 
 module.exports = {
   run: function(argv) {
@@ -38,10 +39,8 @@ module.exports = {
 
     var args = argv.args;
     if (!args.length) {
-      args.push('./tests')
+      args.push(DEFAULT_TEST_DIR);
     }
-    // potential plug-in directories + phantom + appPool
-    deps = qbox.create(args.length + 2);
 
     var compilers = parseCompilers(argv.compilers);
     var isSourceFileAllowed = generateIsSourceFileAllowed(compilers);
@@ -78,7 +77,7 @@ module.exports = {
         'load-images': false
       }});
 
-      args.forEach(loadPlugins);
+      loadPlugins();
 
       //make sure this get ended everytime
       process.once('exit', function() {
@@ -148,12 +147,8 @@ module.exports = {
       });
     }
 
-    function loadPlugins(testsPath) {
-      // could test if path is a dir like for identifyTests, but if it isn't the
-      // package.json is just not going to be found...
-      // TODO: if a test *file* is specified, should we load plugins from the
-      // parent dir? --LaloMartins
-      testsPath = path.resolve(testsPath);
+    function loadPlugins() {
+      testsPath = path.resolve(DEFAULT_TEST_DIR);
       try {
         var json = require(testsPath + '/package.json');
       } catch(error) {

--- a/bin/_laika
+++ b/bin/_laika
@@ -153,6 +153,7 @@ module.exports = {
         var json = require(testsPath + '/package.json');
       } catch(error) {
         if(error.code === 'MODULE_NOT_FOUND') {
+          // maybe later here we import a list of "default" helpers, e.g. phantom
           deps.tick();
           return;
         } else {
@@ -160,39 +161,29 @@ module.exports = {
         }
       }
 
-      var notInstalled = [], spec = [];
-      for(packageName in json.dependencies) {
-        if(!loadPluginPackage(testsPath, packageName)) {
-          notInstalled.push(packageName);
-          spec.push(packageName + '@' + json.dependencies[packageName]);
+      logger.info('  installing and updating plug-ins...');
+      var cwd = process.cwd();
+      process.chdir(testsPath);
+      npm.load({verbose: argv.verbose}, function(error, Npm) {
+        if(error) {
+          // this doesn't seem to ever happen though
+          logger.error('  failed to inintialize Npm');
+          logger.error(error);
+          process.exit(1);
         }
-      }
-      if(notInstalled.length === 0) {
-        initializePlugins();
-      } else {
-        logger.info('  installing plug-ins: ' + notInstalled.join(', '));
-        var cwd = process.cwd();
-        process.chdir(testsPath);
-        npm.load({verbose: argv.verbose}, function(error, Npm) {
-          if(error) {
-            // this doesn't seem to ever happen though
-            logger.error('  failed to inintialize Npm');
-            logger.error(error);
+        Npm.commands.install([], function(error, installed) {
+          if(error != null) {
+            logger.error('  ' + error.message);
             process.exit(1);
           }
-          Npm.commands.install(spec, function(error, installed) {
-            if(error != null) {
-              logger.error('  ' + error.message);
-              process.exit(1);
-            }
-            for(packageName in notInstalled) {
-              loadPluginPackage(testsPath, packageName);
-            }
-            process.chdir(cwd);
-            initializePlugins();
-          });
+          for(packageName in json.dependencies) {
+            loadPluginPackage(testsPath, packageName);
+          }
+          process.chdir(cwd);
+          initializePlugins();
         });
-      }
+      });
+
     }
 
     function loadPluginPackage(where, packageName) {


### PR DESCRIPTION
- unconditionally load plug-ins in ./tests and only there
- always run npm on startup, to either install or update packages; that allows the code to get a bit simpler since npm can read the versions out of package.json itself
