### PR TITLE
remove mongod options until issue 117 is resolved

### DIFF
--- a/_posts/2013-06-1-getting-started.md
+++ b/_posts/2013-06-1-getting-started.md
@@ -15,9 +15,9 @@ visible: true
 
 * Download and install [`phantomJS`](http://phantomjs.org/download.html)
 
-* You need to start a separate `mongodb` server with following options (It makes testing much speedier)
+* You need to start a separate `mongodb` server
 
-    `mongod --smallfiles --noprealloc --nojournal`
+    `mongod`
 
 ##Write your first test with laika
 


### PR DESCRIPTION
Using the `mongod` options will cause client test to fail in 0.8.1. Leaving in the verbiage could confuse new users who are getting started (and using 0.8.1).

https://github.com/arunoda/laika/issues/117
