### PR TITLE
Allow calling done(err)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: node_js
-before_install: 
-  - nvm install 0.10.12
-  - nvm use 0.10.12
-  - node -v
 node_js:
   - "0.8"
-  - "0.10.12"
+  - "0.10"

--- a/bin/_laika
+++ b/bin/_laika
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var Phantom = require('node-phantom');
+var Phantom = require('node-phantom-simple');
 var colors = require('colors');
 var Injector = require('../lib/injector');
 var App = require('../lib/app');

--- a/bin/_laika
+++ b/bin/_laika
@@ -79,8 +79,8 @@ module.exports = {
         throw err;
       } else {
         phantom = ph;
-        phantom._phantom.stdout.on('data', onPhantomLogs);
-        phantom._phantom.stderr.on('data', onPhantomLogs);
+        phantom.process.stdout.on('data', onPhantomLogs);
+        phantom.process.stderr.on('data', onPhantomLogs);
         deps.tick();
       }
     }
@@ -181,8 +181,8 @@ module.exports = {
         logger.info('  cleaning up injected code\n');
         injector.clean();
 
-        phantom._phantom.stdout.removeListener('data', onPhantomLogs);
-        phantom._phantom.stderr.removeListener('data', onPhantomLogs);
+        phantom.process.stdout.removeListener('data', onPhantomLogs);
+        phantom.process.stderr.removeListener('data', onPhantomLogs);
         phantom.exit();
 
         appPool.close(function() {

--- a/lib/test_logic.js
+++ b/lib/test_logic.js
@@ -13,7 +13,7 @@ module.exports = function(appPool, phantom) {
     }
     
     function mockTest(done) { 
-      logger.laika('start running test');   
+      logger.laika('start running test');
       var completed = false;
       var args = [];
       var app;
@@ -51,27 +51,29 @@ module.exports = function(appPool, phantom) {
         });
       }
 
-      function cleanAndDone() {
+      function cleanAndDone(err) {
         if(!completed) {
           args.slice(1).forEach(function(connector) {
             connector.close();
           });
-          completeTest();      
+          completeTest(err);
         }
       }
 
-      function completeTest() {
+      function completeTest(err) {
         logger.laika('test completed');
         if(app) {
-          app.close(completed);
+          app.close(function () {
+            completed(err);
+          });
         } else {
-          completed();
+          completed(err);
         }
 
-        function completed() {
+        function completed(err) {
           logger.laika('closing app');
           completed = true;
-          done();
+          done(err);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "laika": "./bin/laika"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha -u tdd -R spec -t 5000 --recursive test"
+    "test": "node_modules/.bin/mocha -u tdd -R spec -t 10000 --recursive test"
   },
   "author": "Arunoda Susiripala <arunoda.susiripala@gmail.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "version": "0.3.9",
   "description": "end to end testing framework for meteor",
   "dependencies": {
+    "colors": "0.6.x",
+    "commander": "2.0.x",
+    "fibers": "1.0.x",
+    "glob": "3.2.3",
     "handlebars": "1.0.x",
     "mkdirp": "0.3.x",
     "mocha": "https://github.com/arunoda/mocha/archive/master.tar.gz",
-    "node-phantom": "https://github.com/arunoda/node-phantom/archive/master.tar.gz",
-    "colors": "0.6.x",
-    "qbox": "0.1.x",
     "mongodb": "1.3.15",
-    "fibers": "1.0.x",
-    "commander": "2.0.x",
-    "glob": "3.2.3"
+    "node-phantom-simple": "git://github.com/apendua/node-phantom-simple#devel",
+    "qbox": "0.1.x"
   },
   "bin": {
     "laika": "./bin/laika"

--- a/test/clientConnector.js
+++ b/test/clientConnector.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var path = require('path');
 var fs = require('fs');
 var http = require('http');
-var Phantom = require('node-phantom');
+var Phantom = require('node-phantom-simple');
 var helpers = require('../lib/helpers');
 var ClientConnector = require('../lib/connectors/client.js');
 var Fiber = require('fibers');
@@ -200,7 +200,7 @@ suite('ClientConnector', function() {
   });
 
   test('**to kill phantom js**', function() {
-    phantom._phantom.kill();
+    phantom.process.kill();
   });
 })
 


### PR DESCRIPTION
This is a _must-have-feature_ if we want to be able to use promises in tests. Currently, the following test is passing, which is of course an incorrect behavior:

``` javascript
it('Should be able to assert within a promise code.', function (done) {
  Promise.resolve()
    .then(function () {
      expect(true).to.be.false;
    })
    .then(done, done);
});
```
