### PR TITLE
Added a workaround for setTimeout phantomjs bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: node_js
-before_install: 
-  - nvm install 0.10.12
-  - nvm use 0.10.12
-  - node -v
 node_js:
   - "0.8"
-  - "0.10.12"
+  - "0.10"

--- a/lib/injector/templates/client.js
+++ b/lib/injector/templates/client.js
@@ -73,3 +73,49 @@ window.waitForRoute = function(path, callback) {
     Router.go(path);
   }
 }
+
+// XXX this is a very ugly but necessary workaround due to a phantomjs BUG:
+// https://github.com/ariya/phantomjs/issues/10832
+
+var _setTimeout = window.setTimeout;
+var _setInterval = window.setInterval;
+var _clearTimeout = window.clearTimeout;
+var _clearInterval = window.clearInterval;
+var _related = {};
+
+window.setTimeout = function (callback, duration) {
+  var handle = _setTimeout(function () {
+    _related[handle] = _setTimeout(callback, duration);
+  }, 0);
+  return handle;
+};
+
+// XXX this is ugly I guess :P
+window.setInterval = function (callback, interval) {
+  var handle = _setTimeout(function () {
+    _related[handle] = _setInterval(callback, interval);
+  }, 0);
+  return handle;
+};
+
+window.clearTimeout = function (handle) {
+  _setTimeout(function () {
+    var related = _related[handle];
+    if (related !== undefined) {
+      _clearTimeout(related);
+      delete _related[handle];
+    }
+    _clearTimeout(handle);
+  }, 0);
+};
+
+window.clearInterval = function (handle) {
+  _setTimeout(function () {
+    var related = _related[handle];
+    if (related !== undefined) {
+      _clearInterval(related);
+      delete _related[handle];
+    }
+    _clearInterval(handle);
+  }, 0);
+};


### PR DESCRIPTION
It fixes #59. See also https://github.com/ariya/phantomjs/issues/10832

This is a critical issue, since `waitForDOM` depends on it. Please note that `phantomjs` does not support `MutationObserver` API.
