### PR TITLE
ClientConnnector: retry failed page.open

### DIFF
--- a/lib/connectors/client.js
+++ b/lib/connectors/client.js
@@ -28,12 +28,12 @@ function ClientConnector(phantom, appUrl) {
 
   function afterOpened(err, status) {
     if(!pageOpenedCallbackFired) {
-      pageOpenedCallbackFired = true;
       if(err) {
         throw err;
       } else if(status != 'success') {
-        // throw new Error('unsuccessful status: ' + status);
+        page.open(appUrl, afterOpened);  // retry; unclear, should we add a delay
       } else {
+        pageOpenedCallbackFired = true;
         pageOpened = true;
         page.onCallback = onCallback;
         page.onError = onError;


### PR DESCRIPTION
Right now if page.open fails b/c e.g. the server isn’t ready tests will
silently time out. This patch retries instead. This fixed several points
in my app where cases would fail if a few tests were executed before
them.
