### PR TITLE
Fixed --compilers option for CS >= 1.7.x

### DIFF
--- a/_posts/2013-02-22-options.md
+++ b/_posts/2013-02-22-options.md
@@ -16,7 +16,9 @@ A sample `laika.opts` file for coffeescript and bdd is shown below.
 
 <pre><code style='font-weight: bold'>
 --ui bdd
---compilers coffee:coffee-script
+--compilers coffee:coffee-script/register
 --reporter dot
 
 </code></pre>
+
+Use `--compilers coffee:coffee-script` if installed coffeescript <= 1.6.x ([mocha docs](http://visionmedia.github.io/mocha/#compilers-option))


### PR DESCRIPTION
Since laika passes options to mocha, it should be noted that coffeescript 1.7.x has different structure, so small change to options:
http://stackoverflow.com/a/9943255
and
http://visionmedia.github.io/mocha/#compilers-option
