### PR TITLE
We should allow passing error as an argument for done

### DIFF
--- a/lib/test_logic.js
+++ b/lib/test_logic.js
@@ -13,7 +13,7 @@ module.exports = function(appPool, phantom) {
     }
     
     function mockTest(done) { 
-      logger.laika('start running test');   
+      logger.laika('start running test');
       var completed = false;
       var args = [];
       var app;
@@ -51,27 +51,29 @@ module.exports = function(appPool, phantom) {
         });
       }
 
-      function cleanAndDone() {
+      function cleanAndDone(err) {
         if(!completed) {
           args.slice(1).forEach(function(connector) {
             connector.close();
           });
-          completeTest();      
+          completeTest(err);
         }
       }
 
-      function completeTest() {
+      function completeTest(err) {
         logger.laika('test completed');
         if(app) {
-          app.close(completed);
+          app.close(function () {
+            completed(err);
+          });
         } else {
-          completed();
+          completed(err);
         }
 
-        function completed() {
+        function completed(err) {
           logger.laika('closing app');
           completed = true;
-          done();
+          done(err);
         }
       }
     }


### PR DESCRIPTION
This is a _must-have-feature_ if we want to be able to use promises in tests. Currently, the following test is passing, which is of course an incorrect behavior:

``` javascript
it('Should be able to assert within a promise code.', function (done) {
  Promise.resolve()
    .then(function () {
      expect(true).to.be.false;
    })
    .then(done, done);
});
```
