### PR TITLE
Apply settings to the first application launch

### DIFF
--- a/bin/_laika
+++ b/bin/_laika
@@ -46,7 +46,7 @@ module.exports = {
     dropLaikaDbs(checkMongoDB);
 
     function checkMongoDB() {
-      var mongoUrl = "mongodb://localhost:" + argv.mport;
+      var mongoUrl = "mongodb://" + argv.murl + ":" + argv.mport;
       helpers.checkForMongoDB(mongoUrl, function(connected, err) {
         if(connected) {
           initialize();

--- a/bin/_laika
+++ b/bin/_laika
@@ -60,7 +60,7 @@ module.exports = {
     function initialize() {
       logger.info('\n  injecting laika...');
       injector.inject();
-      App.touch(deps.tick.bind(deps), {mongoPort: argv.mport});
+      App.touch(deps.tick.bind(deps), {mongoPort: argv.mport, settingsFile: argv.settings});
 
       logger.info('  loading phantomjs...');
       Phantom.create(afterPhantomCreated, {parameters: {

--- a/bin/_laika
+++ b/bin/_laika
@@ -183,7 +183,7 @@ module.exports = {
 
         phantom._phantom.stdout.removeListener('data', onPhantomLogs);
         phantom._phantom.stderr.removeListener('data', onPhantomLogs);
-        phantom.exit();
+        phantom._phantom.kill();
 
         appPool.close(function() {
           process.exit(exitCode);

--- a/bin/laika
+++ b/bin/laika
@@ -7,6 +7,7 @@ laika = require('./_laika');
 var optionsParser = commander
   .usage('[options] [path filter]')
   .option('-m, --mport <port>', 'specify mongodb port [default: 27017]', 27017)
+  .option('-r, --murl <url>', 'specify mongodb url [default: localhost]', 'localhost')
   .option('-u, --ui <tdd|bdd>', 'specify test user interfaces (tdd|bdd) [default: tdd]', 'tdd')
   .option('-R, --reporter <reporter>', 'specify reporter to use (support all mocha reporters) [default: spec]', 'spec')
   .option('-s, --settings <settings-file>', 'specify a settings file for your meteor app')

--- a/lib/app.js
+++ b/lib/app.js
@@ -111,7 +111,12 @@ App.touch = function touch(callback, options) {
 
   process.env.MONGO_URL = dbUrl;
   var meteorBinary = detectMeteorBinary();
-  var app = spawn(meteorBinary, ['--port', port], {
+  var params = ['--port', port];
+  if (options.settingsFile) {
+    params.push('--settings');
+    params.push(options.settingsFile);
+  }
+  var app = spawn(meteorBinary, params, {
     cwd: options.appDir,
     env: process.env
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "laika",
-  "version": "0.3.9",
+  "name": "eluck-laika",
+  "version": "0.3.10",
   "description": "end to end testing framework for meteor",
   "dependencies": {
     "handlebars": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eluck-laika",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "end to end testing framework for meteor",
   "dependencies": {
     "handlebars": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eluck-laika",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "end to end testing framework for meteor",
   "dependencies": {
     "handlebars": "1.0.x",


### PR DESCRIPTION
When an application under tests was launched first, it didn't recieve settings which were passed as parameter to laika.
Why settings are passed via --settings parameter instead of the environment variable? Because in the latter case settings were applied to an application with a significant delay after start.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/arunoda/laika/149)

<!-- Reviewable:end -->
