### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 laika [![Build Status](https://travis-ci.org/arunoda/laika.png?branch=master)](https://travis-ci.org/arunoda/laika)
 =====
-###testing framework for meteor
+### testing framework for meteor
 
-##[Documentation](http://arunoda.github.io/laika/)
+## [Documentation](http://arunoda.github.io/laika/)
 
 [![Laika - end to end testing framework for meteor](http://i.imgur.com/Q57X7EH.png)](http://arunoda.github.io/laika/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
